### PR TITLE
[fix] fixed error "using Float as a String" when system locale using comma as float separator

### DIFF
--- a/autoload/GoldenView.vim
+++ b/autoload/GoldenView.vim
@@ -25,7 +25,13 @@ function! GoldenView#Init()
         return
     endif
 
-    let s:goldenview__golden_ratio = 1.618
+    let l:golden_ratio_dot = str2float("1.618")
+    let l:golden_ratio_comma = str2float("1,618")
+    if l:golden_ratio_dot > l:golden_ratio_comma
+        let s:goldenview__golden_ratio = l:golden_ratio_dot
+    else
+        let s:goldenview__golden_ratio = l:golden_ratio_comma
+    endif
     lockvar s:goldenview__golden_ratio
 
     set equalalways

--- a/autoload/GoldenView/zl/window.vim
+++ b/autoload/GoldenView/zl/window.vim
@@ -80,7 +80,14 @@ endfunction
 " ============================================================================
 " Move:                                                                   ⟨⟨⟨1
 " ============================================================================
-let s:golden_ratio = 1.618
+let l:golden_ratio_dot = str2float("1.618")
+let l:golden_ratio_comma = str2float("1,618")
+if l:golden_ratio_dot > l:golden_ratio_comma
+    let s:golden_ratio = l:golden_ratio_dot
+else
+    let s:golden_ratio = l:golden_ratio_comma
+endif
+
 function! GoldenView#zl#window#next_window_or_tab()
     if tabpagenr('$') == 1 && winnr('$') == 1
         call GoldenView#zl#window#split_nicely()

--- a/autoload/GoldenView/zl/window.vim
+++ b/autoload/GoldenView/zl/window.vim
@@ -80,12 +80,12 @@ endfunction
 " ============================================================================
 " Move:                                                                   ⟨⟨⟨1
 " ============================================================================
-let l:golden_ratio_dot = str2float("1.618")
-let l:golden_ratio_comma = str2float("1,618")
-if l:golden_ratio_dot > l:golden_ratio_comma
-    let s:golden_ratio = l:golden_ratio_dot
+let s:golden_ratio_dot = str2float("1.618")
+let s:golden_ratio_comma = str2float("1,618")
+if s:golden_ratio_dot > s:golden_ratio_comma
+    let s:golden_ratio = s:golden_ratio_dot
 else
-    let s:golden_ratio = l:golden_ratio_comma
+    let s:golden_ratio = s:golden_ratio_comma
 endif
 
 function! GoldenView#zl#window#next_window_or_tab()


### PR DESCRIPTION
Mac OSX, phpstorm terminal vs system terminal

When LC_NUMERIC="C"
let s:goldenview__golden_ratio = 1.618
end with error using Float as a String

When i set LC_NUMERIC="pl_PL.UTF-8" 
let s:goldenview__golden_ratio = 1.618
without problem.

After fix:
When LC_NUMERIC="C"
let l:golden_ratio_dot = str2float("1.618")  /// 1
let l:golden_ratio_comma = str2float("1,618") /// 1,618
When LC_NUMERIC="pl_PL.UTF-8" 
let l:golden_ratio_dot = str2float("1.618")  /// 1.618
let l:golden_ratio_comma = str2float("1,618") /// 1

Then 
let s:goldenview__golden_ratio = l:golden_ratio_xxxx
and both without errors.
